### PR TITLE
Changes the value of `isOpen` variable before to force the component update.

### DIFF
--- a/index.js
+++ b/index.js
@@ -158,11 +158,11 @@ var SideMenu = React.createClass({
 
     if (!this.isOpen) {
       this.props.onChange(this.isOpen);
+
+      this.isOpen = true;
       // Force update to make the overlay appear (if touchToClose is set)
       this.props.touchToClose && this.forceUpdate();
     }
-
-    this.isOpen = true;
   },
 
   /**
@@ -179,11 +179,11 @@ var SideMenu = React.createClass({
 
     if (this.isOpen) {
       this.props.onChange(this.isOpen);
+
+      this.isOpen = false;
       // Force update to make the overlay disappear (if touchToClose is set)
       this.props.touchToClose && this.forceUpdate();
     }
-
-    this.isOpen = false;
   },
 
   /**


### PR DESCRIPTION
Currently, when the `openMenu` or `closeMenu` functions are called with `props.touchToClose` as `true`, the `TouchableWithoutFeedback` component isn't being rendered because `this.isOpen` still wasn't updated.
So, the value of `isOpen` variable should be updated before call `forceUpdate` in order to render the overlay properly