### PR TITLE
Fixes issue #54: adds explicit width and height to force layout on menu component

### DIFF
--- a/styles.js
+++ b/styles.js
@@ -17,6 +17,8 @@ module.exports = StyleSheet.create({
     position: 'absolute',
     top: 0,
     left: 0,
+    width: deviceScreen.width,
+    height: deviceScreen.height,
   },
   frontView: {
     flex: 1,


### PR DESCRIPTION
In some situations when a component that is passed to the menu prop and is wrapped
within a another Component view that provides no ability to style its view container
the menu view will collapse and hide its contents because the view container may not
have an explicit width and height set.

By adding an explicit width and height to the menu rule it will prevent this from
happening.