### PR TITLE
Adds option to add styles to the menu wrapper and the container elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ var Menu = React.createClass({
 - `onChange` (Function) - Callback on menu open/close. Is passed `isOpen` as an argument.
 - `menuPosition` (String) - either 'left' or 'right', defaults to 'left'
 - `touchToClose` (Bool) - Allows for touching the partially hidden view to close the menu. Defaults to `false`.
+- `menuWrapperStyle` (Object) - Allows for overriding the menu styles.
+- `containerStyle` (Object) - Allows for overriding the container styles.
 
 *In progress*
 

--- a/index.js
+++ b/index.js
@@ -284,7 +284,7 @@ class SideMenu extends Component {
     var menuActions = this.getMenuActions();
 
     return (
-      <View style={styles.menu}>
+      <View style={[styles.menu, this.props.menuWrapperStyle]}>
         {React.addons.cloneWithProps(this.props.menu, { menuActions, })}
       </View>
     );
@@ -296,7 +296,7 @@ class SideMenu extends Component {
    */
   render() {
     return (
-      <View style={styles.container}>
+      <View style={[styles.container, this.props.containerStyle]}>
         {this.getMenuView()}
         {this.getContentView()}
       </View>


### PR DESCRIPTION
I want to create a menu like this:

![image](https://cloud.githubusercontent.com/assets/1201847/8270312/72eebaf8-17b0-11e5-83ed-2c3d4e042458.png)


Currently it's not possible because:
- the menu background [is set as transparent](https://github.com/Kureev/react-native-side-menu/blob/master/styles.js#L16);
- the menu position [is set to absolute](https://github.com/Kureev/react-native-side-menu/blob/master/styles.js#L17);
- the container alignment [is set to center](https://github.com/Kureev/react-native-side-menu/blob/master/styles.js#L12);

This PR allows to override these rules.

Also check if these rules are really necessary.
IMO you added these rules just for centralize the [menu of the example](https://github.com/Kureev/react-native-side-menu/tree/master/examples/simple).
So, I think these rules shouldn't be part of the default style of the react-native-side-menu component.

If you agree, I can removing these rules from the default [styles.js](https://github.com/Kureev/react-native-side-menu/blob/master/styles.js). Otherwise, you can just merge this pull request.

Thanks.