### PR TITLE
Fixed syntax error: "`this` is not allowed before super()"

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ function noop() {}
 
 class SideMenu extends Component {
   constructor(props) {
-    super(props)
+    super(props);
     
     /**
      * Current state of the menu, whether it is open or not

--- a/index.js
+++ b/index.js
@@ -47,6 +47,8 @@ function noop() {}
 
 class SideMenu extends Component {
   constructor(props) {
+    super(props)
+    
     /**
      * Current state of the menu, whether it is open or not
      * @type {Boolean}


### PR DESCRIPTION
I was getting a syntax error crash on React Native 0.6.0-rc from babel.  This fixes it.  

Added one additional commit for repo style conformance.