### PR TITLE
Fixed React Native warning about incorrect prop types

### DIFF
--- a/index.js
+++ b/index.js
@@ -301,7 +301,7 @@ SideMenu.propTypes = {
   toleranceY: React.PropTypes.number,
   onChange: React.PropTypes.func,
   touchToClose: React.PropTypes.bool,
-  disableGestures: React.PropTypes.oneOf([React.PropTypes.func, React.PropTypes.bool]),
+  disableGestures: React.PropTypes.oneOfType([React.PropTypes.func, React.PropTypes.bool]),
 };
 
 SideMenu.defaultProps = {


### PR DESCRIPTION
I was receiving a warning about the prop types from the current version of `react-native-side-menu` with React Native `0.8.0`. Screenshot below:

![screen shot 2015-08-12 at 3 52 21 pm](https://cloud.githubusercontent.com/assets/792606/9238846/88eadfc0-410a-11e5-9b76-9994e5c3b565.png)

I believe you want to use `oneOfType` not `oneOf`. Looking at the source code for type validation in React Native, `oneOfType` checks against existing system types, as you've defined. While `oneOf` uses literal comparison.

```
oneOf: createEnumTypeChecker,
oneOfType: createUnionTypeChecker,
```

Switching to `oneOfType` removes the warning and ensures proper type checking.