### PR TITLE
Don't queueAnimation if there is nothing to do

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,7 +143,7 @@ class SideMenu extends Component {
    * @return {Void}
    */
   openMenu() {
-    if (this.isOpen) {
+    if (this.left === this.prevLeft && this.isOpen) {
       return;
     }
 
@@ -172,7 +172,7 @@ class SideMenu extends Component {
    * @return {Void}
    */
   closeMenu() {
-    if (!this.isOpen) {
+    if (this.left === this.prevLeft && !this.isOpen) {
       return;
     }
 

--- a/index.js
+++ b/index.js
@@ -143,6 +143,10 @@ class SideMenu extends Component {
    * @return {Void}
    */
   openMenu() {
+    if (this.isOpen) {
+      return;
+    }
+
     queueAnimation(this.props.animation);
 
     this.left = this.menuPositionMultiplier() *
@@ -168,6 +172,10 @@ class SideMenu extends Component {
    * @return {Void}
    */
   closeMenu() {
+    if (!this.isOpen) {
+      return;
+    }
+
     queueAnimation(this.props.animation);
     this.left = this.menuPositionMultiplier() *
       (this.props.hiddenMenuOffset || hiddenMenuOffset);


### PR DESCRIPTION
I'm not 100% sure why, but without this PR `<Navigator>` could have some issues with the default animation triggered by `pop()`. Somehow the animations interfere and the result is buggy/broken/ugly. 

A (somewhat hacky) solution for my case would be a delay infront of `Navigator.pop()`. But, IMHO, the solution in this PR is far superior, as we save some precious CPU cycles :)

Or is there a valid case to queue the open/close animation multiple times? I'm a bit confused, as there is already as state check in both `openMenu` and `closeMenu`, but only for the non-animation related stuff .. :|

(Tested with react-native 0.9.0-rc)