### PR TITLE
calling animationFunction at constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,10 @@ class SideMenu extends Component {
     this.state = {
       left: new Animated.Value(0),
     };
+    
+    //we need to call animationFunction to make sure that user has enough time to add its own 
+    //listeners to Animated api.
+    props.animationFunction(this.state.left, 0);
   }
 
 


### PR DESCRIPTION
I think we need to call `animationFunction` at the beginning. There reason for that is, adding listeners to Animated API wont trigger until onOpen is called first. Which cause an issue of missing the first events.

we can also put this one in `componentDidMount`. 

@Kureev  Any thoughts on that?