### PR TITLE
fix panResponder when menuPosition is set to 'right'

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,8 +116,9 @@ class SideMenu extends Component {
    * @return {Void}
    */
   handlePanResponderMove(e: Object, gestureState: Object) {
-    if (this.menuPositionMultiplier() *
-      this.state.left.__getValue() + gestureState.dx >= 0) {
+    if ((this.props.menuPosition === 'left'  && (this.state.left.__getValue() + gestureState.dx >= 0)) ||
+        (this.props.menuPosition === 'right' && (this.state.left.__getValue() + gestureState.dx <= 0))) {
+
       this.state.left.setValue(this.prevLeft + gestureState.dx);
     }
   }

--- a/index.js
+++ b/index.js
@@ -116,8 +116,8 @@ class SideMenu extends Component {
    * @return {Void}
    */
   handlePanResponderMove(e: Object, gestureState: Object) {
-    if ((this.props.menuPosition === 'left'  && (this.state.left.__getValue() + gestureState.dx >= 0)) ||
-        (this.props.menuPosition === 'right' && (this.state.left.__getValue() + gestureState.dx <= 0))) {
+    if (this.menuPositionMultiplier() * 
+      (this.state.left.__getValue() + gestureState.dx ) >= 0 ) {
 
       this.state.left.setValue(this.prevLeft + gestureState.dx);
     }


### PR DESCRIPTION
The `frontView` will respond to pan gesture from left to right when `menuPosition` is set to `right`, which is a wrong behavior. It should be set to work only when we pan from right to left.