### PR TITLE
Make the open gesture claim the responder less greedily

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ Button.contextTypes = {
 - `menu` (React.Component) - Menu component
 - `openMenuOffset` (Number) - Content view left margin if menu is opened
 - `hiddenMenuOffset` (Number) - Content view left margin if menu is hidden
-- `edgeHitWidth` (Number) - Maximum distance from the screen edge that will be recognised as an open gesture
 - `toleranceX` (Number) - X axis tolerance
 - `toleranceY` (Number) - Y axis tolerance
 - `disableGestures` (Bool) - Disable whether the menu can be opened with gestures or not

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Button.contextTypes = {
 - `menu` (React.Component) - Menu component
 - `openMenuOffset` (Number) - Content view left margin if menu is opened
 - `hiddenMenuOffset` (Number) - Content view left margin if menu is hidden
+- `edgeHitWidth` (Number) - Maximum distance from the screen edge that will be recognised as an open gesture
 - `toleranceX` (Number) - X axis tolerance
 - `toleranceY` (Number) - Y axis tolerance
 - `disableGestures` (Bool) - Disable whether the menu can be opened with gestures or not

--- a/index.js
+++ b/index.js
@@ -114,9 +114,11 @@ class SideMenu extends Component {
       if (this.isOpen) {
         return touchMoved;
       } else {
-        const withinEdgeHitWidth = gestureState.moveX < this.props.edgeHitWidth;
-        const swipingRight = gestureState.dx > 0;
-        return withinEdgeHitWidth && touchMoved && swipingRight;
+        const withinEdgeHitWidth = this.props.menuPosition === 'right' ?
+            gestureState.moveX > (deviceScreen.width - edgeHitWidth) :
+            gestureState.moveX < edgeHitWidth;
+        const swipingToOpen = (this.menuPositionMultiplier() * gestureState.dx) > 0;
+        return withinEdgeHitWidth && touchMoved && swipingToOpen;
       }
     }
 
@@ -296,7 +298,7 @@ SideMenu.childContextTypes = {
 SideMenu.propTypes = {
   toleranceX: React.PropTypes.number,
   toleranceY: React.PropTypes.number,
-  edgeHitWidth: React.PropTypes.number,
+  menuPosition: React.PropTypes.oneOf(['left', 'right']),
   onChange: React.PropTypes.func,
   touchToClose: React.PropTypes.bool,
   disableGestures: React.PropTypes.oneOfType([React.PropTypes.func, React.PropTypes.bool, ]),
@@ -307,7 +309,6 @@ SideMenu.propTypes = {
 SideMenu.defaultProps = {
   toleranceY: 10,
   toleranceX: 10,
-  edgeHitWidth: edgeHitWidth,
   touchToClose: false,
   onStartShouldSetResponderCapture: () => true,
   onChange: () => {},

--- a/index.js
+++ b/index.js
@@ -24,6 +24,13 @@ const openMenuOffset = deviceScreen.width * 2 / 3;
 const hiddenMenuOffset = 0;
 
 /**
+ * Default edge hit width for determining whether a swipe can be claimed as
+ * a swipe to open the menu
+ * @type {Number}
+ */
+const edgeHitWidth = 60;
+
+/**
  * Size of the amount you can move content view in the opened menu state and
  * release without menu closing
  * @type {Number}
@@ -103,7 +110,14 @@ class SideMenu extends Component {
       const x = Math.round(Math.abs(gestureState.dx));
       const y = Math.round(Math.abs(gestureState.dy));
 
-      return x > this.props.toleranceX && y < this.props.toleranceY;
+      const touchMoved = x > this.props.toleranceX && y < this.props.toleranceY;
+      if (this.isOpen) {
+        return touchMoved;
+      } else {
+        const withinEdgeHitWidth = gestureState.moveX < this.props.edgeHitWidth;
+        const swipingRight = gestureState.dx > 0;
+        return withinEdgeHitWidth && touchMoved && swipingRight;
+      }
     }
 
     return false;
@@ -282,6 +296,7 @@ SideMenu.childContextTypes = {
 SideMenu.propTypes = {
   toleranceX: React.PropTypes.number,
   toleranceY: React.PropTypes.number,
+  edgeHitWidth: React.PropTypes.number,
   onChange: React.PropTypes.func,
   touchToClose: React.PropTypes.bool,
   disableGestures: React.PropTypes.oneOfType([React.PropTypes.func, React.PropTypes.bool, ]),
@@ -292,6 +307,7 @@ SideMenu.propTypes = {
 SideMenu.defaultProps = {
   toleranceY: 10,
   toleranceX: 10,
+  edgeHitWidth: edgeHitWidth,
   touchToClose: false,
   onStartShouldSetResponderCapture: () => true,
   onChange: () => {},


### PR DESCRIPTION
The open gesture is currently very greedy: it sets itself the responder
whenever the touch moves more than 10px in the horizontal. This prevents other
components using horizontal swipe type interaction further down the component
hierarchy.

This commit changes this behaviour when the menu is closed. Responder is only
set if:
 * touch moves horizontally 10px (as before)
 * we're near the left edge of the screen (configurable)
 * we're swiping right